### PR TITLE
Fix Kotlin code generation for arrays with nullable elements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ru.curs</groupId>
     <artifactId>hurdy-gurdy</artifactId>
-    <version>1.23</version>
+    <version>1.24-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>OpenAPI codegen Maven Plugin</name>

--- a/src/main/java/ru/curs/hurdygurdy/KotlinTypeDefiner.kt
+++ b/src/main/java/ru/curs/hurdygurdy/KotlinTypeDefiner.kt
@@ -86,7 +86,7 @@ class KotlinTypeDefiner internal constructor(
                     val itemsSchema: Schema<*> = (schema as ArraySchema).items
                     List::class.asTypeName().parameterizedBy(
                         defineKotlinType(itemsSchema, openAPI, parent, typeNameFallback?.plus("Item"))
-                            .copy(nullable = false)
+                            .copy(nullable = (itemsSchema.nullable ?: false))
                     )
                 }
                 "object" -> {

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.doNotGenerateResponseParameter.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.doNotGenerateResponseParameter.approved.txt
@@ -155,6 +155,8 @@ public class MenuItemDTO implements Serializable {
 
   private List<MenuItemDTO> menuItems;
 
+  private List<String> menuTips;
+
   private boolean boolValue;
 
   private Integer intValue;

--- a/src/test/java/ru/curs/hurdygurdy/CodegenTest.generateSample1.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/CodegenTest.generateSample1.approved.txt
@@ -105,6 +105,8 @@ public class MenuItemDTO implements Serializable {
 
   private List<MenuItemDTO> menuItems;
 
+  private List<String> menuTips;
+
   private boolean boolValue;
 
   private Integer intValue;

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.doNotGenerateResponseParameter.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.doNotGenerateResponseParameter.approved.txt
@@ -150,6 +150,7 @@ public data class MenuItemDTO(
   public val enabled: Boolean? = null,
   public val name: String = "Default name",
   public val menuItems: List<MenuItemDTO> = listOf(),
+  public val menuTips: List<String?>,
   public val boolValue: Boolean? = false,
   public val intValue: Int? = 42,
   public val strValue: String? = null,

--- a/src/test/java/ru/curs/hurdygurdy/KCodegenTest.generateSample1.approved.txt
+++ b/src/test/java/ru/curs/hurdygurdy/KCodegenTest.generateSample1.approved.txt
@@ -101,6 +101,7 @@ public data class MenuItemDTO(
   public val enabled: Boolean? = null,
   public val name: String = "Default name",
   public val menuItems: List<MenuItemDTO> = listOf(),
+  public val menuTips: List<String?>,
   public val boolValue: Boolean? = false,
   public val intValue: Int? = 42,
   public val strValue: String? = null,

--- a/src/test/resources/sample1.yaml
+++ b/src/test/resources/sample1.yaml
@@ -138,6 +138,13 @@ components:
           items:
             $ref: "#/components/schemas/MenuItemDTO"
           default: []
+        menu_tips:
+          description: "Menu pop-over tips"
+          type: array
+          nullable: false
+          items:
+            type: string
+            nullable: true
         bool_value:
           type: boolean
           default: false


### PR DESCRIPTION
Currently, the following definition
```yaml
type: array
items:
   type: string
   nullable: true
```
results in `List<String>`. It can be seen that `nullable` spec parameter is ignored.

This change fixes behavior to generate `List<T?>` when `nullable: true` is specified, and `List<T>` in case of `nullable: false` or unspecified `nullable` parameter.